### PR TITLE
Bugfix: The returned timestamp was not the NEXT one

### DIFF
--- a/Crontab.class.php
+++ b/Crontab.class.php
@@ -67,13 +67,14 @@ class Crontab {
                             'dow'       =>self::_parseCronNumbers($cron[4],0,6),
                         );
         // limited to time()+366 - no need to check more than 1year ahead
+        $compareDateFormat = 'j|n|w|g|i';
         for($i=0;$i<=60*60*24*366;$i+=60){
             if( in_array(intval(date('j',$start+$i)),$date['dom']) &&
                 in_array(intval(date('n',$start+$i)),$date['month']) &&
                 in_array(intval(date('w',$start+$i)),$date['dow']) &&
                 in_array(intval(date('G',$start+$i)),$date['hours']) &&
-                in_array(intval(date('i',$start+$i)),$date['minutes'])
-
+                in_array(intval(date('i',$start+$i)),$date['minutes']) &&
+                date($compareDateFormat, $start) !== date($compareDateFormat, $start+$i)
                 ){
                     return $start+$i;
             }

--- a/README
+++ b/README
@@ -1,6 +1,5 @@
 This is a simple cron notation parser. Returns the 
 nearest timestamp matching given criteria that is
-greater than given timestamp (current
-time() by default)
+greater than given timestamp (current time() by default)
  
 Eg.:   $timestamp = Crontab::parse('12 * * * 1-5');

--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 This is a simple cron notation parser. Returns the 
 nearest timestamp matching given criteria that is
-greater than or equal to given timestamp (current
+greater than given timestamp (current
 time() by default)
  
 Eg.:   $timestamp = Crontab::parse('12 * * * 1-5');


### PR DESCRIPTION
Crontab behaves not like written in the docs.
Documentation:  int unix timestamp - next execution time will be greater than given timestamp

```
"*/1 * * * *"

Before:
  In:  Monday, 05-Aug-13 14:53:27 CEST
  Out: Monday, 05-Aug-13 14:53:27 CEST

After:
  In:  Monday, 05-Aug-13 14:53:27 CEST
  Out: Monday, 05-Aug-13 14:54:27 CEST
```

Beware: This breaks the API!
